### PR TITLE
Add Dockerfile and Docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+FROM python:3.9.0
+
+WORKDIR /src
+
+ENV FLASK_APP=flight_club
+ENV FLASK_RUN_HOST=0.0.0.0
+
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+EXPOSE 5000
+
+CMD ["flask", "run"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,17 @@
 # flight_club
-App for flight cluib
 
-Need to make this better later
+# Running in container
+## System dependencies
+1. `docker`
+2. `docker-compose`
+
+## Running Locally
+1. Run:
+```
+docker-compose up dev
+```
+2. In a browser navigate to:
+```
+0.0.0.0:5000
+```
+Congrats you are now running the flight club app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+version: "3.8"
+
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ".:/src"
+    ports:
+      - "5000:5000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-SQLAlchemy==2.4.1
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-pkg-resources==0.0.0
 pycodestyle==2.5.0
 SQLAlchemy==1.3.16
 Werkzeug==1.0.1


### PR DESCRIPTION
Fixes #3.  This adds a Dockerfile and a docker-compose.yml which makes running the  app in a container possible.  This is a trivial thing to do on *nix systems, untested but possible on Windows.

Note: this unilaterally puts files under the GPL v3 license.  I can remove those headers if you'd prefer a different license, I chose it because I like GPL for personal projects.