### PR TITLE
removed pkg-resources from requirements it breaks pip install on mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Flask-SQLAlchemy==2.4.1
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-pkg-resources==0.0.0
 pycodestyle==2.5.0
 SQLAlchemy==1.3.16
 Werkzeug==1.0.1


### PR DESCRIPTION
and is unnecessary to add in linux, i think pip puts it in by default or something depending on how you generated requirements.txt