### PR TITLE
Fix bug in average score and abv calculation for FCMember class.

### DIFF
--- a/flight_club/users/fc_member.py
+++ b/flight_club/users/fc_member.py
@@ -30,11 +30,15 @@ class FCMember:
         self._win_count = len(self._wins)
 
     def _determine_scores(self):
-        self._avg_score = (
+        query_result = (
             Beer.query.with_entities(func.avg(Beer.votes).label("avg"))
             .filter_by(username=self._username)
             .all()[0][0]
         )
+        if query_result is None:
+            self._avg_score = 0.0
+        else:
+            self._avg_score = query_result
 
     def _determine_average_abv(self):
         query_result = (

--- a/flight_club/users/fc_member.py
+++ b/flight_club/users/fc_member.py
@@ -37,12 +37,15 @@ class FCMember:
         )
 
     def _determine_average_abv(self):
-        self._avg_abv = round(
+        query_result = (
             Beer.query.with_entities(func.avg(Beer.beer_abv).label("avg"))
             .filter_by(username=self._username)
-            .all()[0][0],
-            2,
+            .all()[0][0]
         )
+        if query_result is None:
+            self._avg_abv = 0.0
+        else:
+            self._avg_abv = round(query_result, 2)
 
     @property
     def username(self):

--- a/tests/fixtures/app_fixtures.py
+++ b/tests/fixtures/app_fixtures.py
@@ -2,10 +2,12 @@ import pytest
 
 from flight_club import create_app
 
+
 @pytest.fixture(scope="module")
 def app():
     app = create_app()
     yield app
+
 
 @pytest.fixture(scope="module")
 def test_client(app):

--- a/tests/functional/test_auth.py
+++ b/tests/functional/test_auth.py
@@ -5,51 +5,58 @@ from flight_club.models.models import User
 
 from flask import g, session
 
+
 def test_register(test_client, app):
     # The registration page works
     response = test_client.get("/auth/register")
-    assert(response.status_code == 200)
+    assert response.status_code == 200
 
     # Test registration brings to login page
-    response = test_client.post("/auth/register", data={"username":"test", "password":"test"})
+    response = test_client.post(
+        "/auth/register", data={"username": "test", "password": "test"}
+    )
     assert "auth/login" in response.headers["Location"]
 
     with app.app_context():
         assert db.session.query(User.query.filter_by(username="test").exists()).scalar()
-    
+
+
 def test_login(test_client, app):
-    
+
     with app.app_context():
         assert db.session.query(User.query.filter_by(username="test").exists()).scalar()
-    
+
     # Check the login page works
     response = test_client.get("/auth/login")
-    assert(response.status_code == 200)
+    assert response.status_code == 200
 
     # Test ability to login
-    response = test_client.post("/auth/login", data={"username":"test", "password":"test"})
-    
+    response = test_client.post(
+        "/auth/login", data={"username": "test", "password": "test"}
+    )
+
     # Assert there was a redirect to homepage
-    assert(response.status_code == 302)
-    assert(response.headers["Location"] == "http://localhost/")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "http://localhost/"
 
     # Check the session context is good
     with test_client:
         test_client.get("/")
-        assert(g.username == "test")
+        assert g.username == "test"
+
 
 def test_logout(test_client, app):
     # Login
-    response = test_client.post("/auth/login", data={"username":"test", "password":"test"})
-    
+    response = test_client.post(
+        "/auth/login", data={"username": "test", "password": "test"}
+    )
+
     # Logout
     with test_client:
         response = test_client.get("/auth/logout")
 
         # Assert there was a redirect to homepage
-        assert(response.status_code == 302)
-        assert(response.headers["Location"] == "http://localhost/")
+        assert response.status_code == 302
+        assert response.headers["Location"] == "http://localhost/"
 
-        assert("user_id" not in session)
-
-
+        assert "user_id" not in session

--- a/tests/functional/test_basics.py
+++ b/tests/functional/test_basics.py
@@ -1,9 +1,10 @@
 from flight_club import create_app
 
+
 def test_home_page():
 
     flask_app = create_app()
 
     with flask_app.test_client() as test_client:
-        response = test_client.get('/')
-        assert(response.status_code == 200)
+        response = test_client.get("/")
+        assert response.status_code == 200

--- a/tests/functional/test_db_func.py
+++ b/tests/functional/test_db_func.py
@@ -3,53 +3,58 @@ import pytest
 from flight_club import db
 import flight_club.models.db_func as db_func
 
+
 def test_no_user_check(app, test_client):
     # This database should be empty at the start.
     with app.app_context():
-        assert(db_func.check_if_user_exists("test") == False)
+        assert db_func.check_if_user_exists("test") == False
+
 
 def test_add_user(app, test_client):
     # Test adding a user
     with app.app_context():
         db_func.add_user("test", "test")
-        assert(db_func.check_if_user_exists("test") == True)
+        assert db_func.check_if_user_exists("test") == True
+
 
 def test_no_session_check(app, test_client):
     # This database should be empty at the start.
     with app.app_context():
-        assert(db_func.check_if_session_exists(1) == False)
+        assert db_func.check_if_session_exists(1) == False
+
 
 def test_add_session(app, test_client):
     with app.app_context():
-        db_func.add_session(1,"1/1/2020")
-        assert(db_func.check_if_session_exists(1) == True)
+        db_func.add_session(1, "1/1/2020")
+        assert db_func.check_if_session_exists(1) == True
+
 
 def test_add_beer(app, test_client):
     with app.app_context():
         # TODO right now this is an annoying csv row
         beer = []
-        beer.append(str(1))             # 0 - Session ID string
-        beer.append("")                 # 1 - Unused
-        beer.append("test")             # 2 - Username
-        beer.append("")                 # 3 - Unused
-        beer.append("Cool Beer Name")   # 4 - beername
-        beer.append("Hip Brewery")      # 5 - brewery
-        beer.append(str(2))             # 6 - votes
-        beer.append(str(1))             # 7 - win
-        beer.append("")                 # 8 - unused
-        beer.append("IPA")              # 9 - style
-        beer.append(str(6.12))          # 10 - abv
+        beer.append(str(1))  # 0 - Session ID string
+        beer.append("")  # 1 - Unused
+        beer.append("test")  # 2 - Username
+        beer.append("")  # 3 - Unused
+        beer.append("Cool Beer Name")  # 4 - beername
+        beer.append("Hip Brewery")  # 5 - brewery
+        beer.append(str(2))  # 6 - votes
+        beer.append(str(1))  # 7 - win
+        beer.append("")  # 8 - unused
+        beer.append("IPA")  # 9 - style
+        beer.append(str(6.12))  # 10 - abv
 
         db_func.add_beer(beer)
 
         # Query Database for Beer
         res_beer = db_func.get_beer("Cool Beer Name")
-        assert(len(res_beer) == 1)
-        assert(res_beer[0].id == 1)
-        assert(res_beer[0].beer_name == "Cool Beer Name")
-        assert(res_beer[0].brewery == "Hip Brewery")
-        assert(res_beer[0].style == "IPA")
-        assert(res_beer[0].votes == 2)
-        assert(res_beer[0].win == 1)
-        assert(res_beer[0].username == "test")
-        assert(res_beer[0].session_id == 1)
+        assert len(res_beer) == 1
+        assert res_beer[0].id == 1
+        assert res_beer[0].beer_name == "Cool Beer Name"
+        assert res_beer[0].brewery == "Hip Brewery"
+        assert res_beer[0].style == "IPA"
+        assert res_beer[0].votes == 2
+        assert res_beer[0].win == 1
+        assert res_beer[0].username == "test"
+        assert res_beer[0].session_id == 1

--- a/tests/functional/test_profile.py
+++ b/tests/functional/test_profile.py
@@ -1,0 +1,26 @@
+import pytest
+
+from flight_club import db
+from flight_club.users.fc_member import FCMember
+
+from flask import g, session, json, jsonify
+import flight_club.models.db_func as db_func
+
+
+def test_new_user_object(test_client, app):
+    with app.app_context():
+        # Add a simple user
+        db_func.add_user("test", "test")
+        new_user = FCMember("test")
+        assert new_user.username == "test"
+        assert new_user.win_count == 0
+        assert not new_user.beers
+        assert not new_user.wins
+        assert new_user.avg_score == 0.0
+        assert new_user.avg_abv == 0.0
+
+
+def test_new_user_page(test_client, app):
+    with app.app_context():
+        response = test_client.get("/users/test")
+        assert response.status_code == 200


### PR DESCRIPTION
The `FCMember` class had some bad behavior for new users that would crash the profile page. It would throw an exception on the round call for the database query when a user has no beers, and return a None for the score when a user had no beers. I think it's definitely not out of the use case for there to be a member with no beers, and we don't strictly enforce it so this needs to work. Sessions we do enforce must have a single beer. (Or are supposed to) I also added testing for a new user's `FCMember` object and that calling their profile doesn't lead to an error page.

Additionally I ran formatting on the tests directory so we could be good about that.